### PR TITLE
Twitterログアウト機能の実装 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  helper_method :logged_in?
+
+  private
+
+  def logged_in?
+    !!session[:user_id]
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,4 +4,9 @@ class SessionsController < ApplicationController
     session[:user_id] = user.id
     redirect_to root_path, notice: 'ログインしました'
   end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: 'ログアウトしました'
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,11 @@
         <div class="collapse navbar-collapse" id="Navber">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
+              <% if logged_in? %>
+              <%= link_to 'ログアウト', logout_path, class: 'nav-link' %>
+              <% else %>
               <%= link_to 'Twitterでログイン', '/auth/twitter', class: 'nav-link' %>
+              <% end %>
             </li>
           </ul>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
+  get '/logout' => 'sessions#destroy', as: :logout
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'SessionsRequest', type: :request do
     )
   end
 
-  # get '/auth/twitter' の後にコールバックが実行されないため、直接コールバックURLを GET する
-  subject { get '/auth/twitter/callback' }
-
   describe 'GET /auth/twitter/callback' do
+    # get '/auth/twitter' の後にコールバックが実行されないため、直接コールバックURLを GET する
+    subject { get '/auth/twitter/callback' }
+
     context 'ユーザが未登録の場合' do
       let(:user) { build(:user) }
 
@@ -51,6 +51,21 @@ RSpec.describe 'SessionsRequest', type: :request do
         subject
         expect(response).to be_redirect
       end
+    end
+  end
+
+  describe 'GET /logout' do
+    subject { get '/logout' }
+    let!(:user) { build(:user) }
+
+    it 'session の user_id が nil になっているいること' do
+      subject
+      expect(session[:user_id]).to be_nil
+    end
+
+    it 'HTTP Status 3xx が返ってくること' do
+      subject
+      expect(response).to be_redirect
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'SessionsRequest', type: :request do
     )
   end
 
-  describe 'GET /auth/twitter/callback' do
+  describe 'GET #create' do
     # get '/auth/twitter' の後にコールバックが実行されないため、直接コールバックURLを GET する
     subject { get '/auth/twitter/callback' }
 
@@ -54,7 +54,7 @@ RSpec.describe 'SessionsRequest', type: :request do
     end
   end
 
-  describe 'GET /logout' do
+  describe 'GET #destroy' do
     subject { get '/logout' }
     let!(:user) { build(:user) }
 

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -15,18 +15,49 @@ RSpec.describe 'SessionsSystem', type: :system do
 
   let(:user) { build(:user) }
 
-  context '"Twitterログイン"をクリックした時' do
+  context 'ログアウト時' do
+    before { visit root_path }
+
+    it '"Twitterでログイン"リンクが表示されること' do
+      expect(page).to have_content 'Twitterでログイン'
+    end
+
+    context '"Twitterログイン"をクリックした時' do
+      before do
+        visit root_path
+        click_link 'Twitterでログイン'
+      end
+
+      it 'トップページに遷移していること' do
+        expect(page.current_path).to eq root_path
+      end
+
+      it 'ログインしましたと表示されること' do
+        expect(page).to have_content 'ログインしました'
+      end
+    end
+  end
+
+  context 'ログイン時' do
     before do
       visit root_path
       click_link 'Twitterでログイン'
     end
 
-    it 'トップページに遷移していること' do
-      expect(page.current_path).to eq root_path
+    it '"ログアウト"リンクが表示されること' do
+      expect(page).to have_content 'ログアウト'
     end
 
-    it 'ログインしましたと表示されること' do
-      expect(page).to have_content 'ログインしました'
+    context '"ログアウト"をクリックした時' do
+      before { click_link 'ログアウト' }
+
+      it 'トップページに遷移していること' do
+        expect(page.current_path).to eq root_path
+      end
+
+      it 'ログアウトしましたと表示されること' do
+        expect(page).to have_content 'ログアウトしました'
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
### ログアウト処理実装
- セッション情報を削除する `sessions#destroy` を実装
- `/logout` を `sessions#destroy` にルーティング
    - 別名を `logout` に設定

### ログアウトリンク作成
- ログイン状態を確認するヘルパーメソッドの `#logged_in` を実装
- ヘッダーに「ログアウト」リンク作成
- ログイン時は「ログアウト」、ログアウト時は「Twitterでログイン」を表示する条件分岐を設定

### ログアウト機能の System Spec 作成
- ログイン時とログアウト時のリンクの条件分岐のテストを記述
- ログイン時のユーザのリンククリック動作に対して、画面遷移、表示メッセージのテストを記述

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/ にアクセスする
- 画面右上の `Twitterでログイン` をクリックする
- 画面右上の `ログアウト` をクリックする
- 下図画面が表示され、 Twitterログアウトが成功していることを確認する
<img width="600" alt="2018-07-02 10 42 47" src="https://user-images.githubusercontent.com/26681827/42141532-c0b9c9ec-7de4-11e8-804a-7ffe32897c84.png">

### 2. RSpec
- `$ bundle exec rspec` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する

## その他
### 特記事項
- `ApplicationController.helper_method`
    - コントローラメソッドがビューで使用可能になる。
- `ApplicationController.protect_from_forgery`
    - アクション実行前に正しいトークンが付随されているかをチェックする。
    - `rails/rails` [Default protect from forgery #29742](https://github.com/rails/rails/pull/29742) でデフォルトに設定されてるため記述せず。
