### PR TITLE
Event Model の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,5 @@ group :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
     selenium-webdriver (3.12.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -260,6 +262,7 @@ DEPENDENCIES
   rubocop (= 0.55.0)
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/events.coffee
+++ b/app/assets/javascripts/events.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,2 @@
+class EventsController < ApplicationController
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,16 @@
 class Event < ApplicationRecord
+  validates :name, length: { maximum: 50 }, presence: true
+  validates :place, length: { maximum: 100 }, presence: true
+  validates :content, length: { maximum: 2000 }, presence: true
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+  validate :start_time_should_be_before_end_time
+
+  private
+
+  def start_time_should_be_before_end_time
+    return unless start_time && end_time
+
+    errors.add(:start_time, 'は終了時間よりも前に設定してください') if start_time >= end_time
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   root to: 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout
+
+  resources :events
 end

--- a/db/migrate/20180702074641_create_events.rb
+++ b/db/migrate/20180702074641_create_events.rb
@@ -1,0 +1,16 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.integer :owner_id
+      t.string :name,         null: false
+      t.string :place,        null: false
+      t.datetime :start_time, null: false
+      t.datetime :end_time,   null: false
+      t.text :content,        null: false
+
+      t.timestamps
+    end
+
+    add_index :events, :owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_21_071104) do
+ActiveRecord::Schema.define(version: 2018_07_02_074641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.integer "owner_id"
+    t.string "name", null: false
+    t.string "place", null: false
+    t.datetime "start_time", null: false
+    t.datetime "end_time", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_events_on_owner_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :event do
-    sequence(:owner_id, 1)
+    owner_id 1
     name 'TEST_EVENT_NAME'
     place 'TEST_EVENT_PLACE'
     content 'TEST_EVENT_CONTENT'
-    start_time '2018-07-07 19:00:00'.in_time_zone
-    end_time '2018-07-07 21:00:00'.in_time_zone
+    start_time '2018-07-07 19:00:00'
+    end_time '2018-07-07 21:00:00'
   end
 end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :event do
+    sequence(:owner_id, 1)
+    name 'TEST_EVENT_NAME'
+    place 'TEST_EVENT_PLACE'
+    content 'TEST_EVENT_CONTENT'
+    start_time '2018-07-07 19:00:00'.in_time_zone
+    end_time '2018-07-07 21:00:00'.in_time_zone
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  describe '#name' do
+    it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_most(50) }
+  end
+
+  describe '#place' do
+    it { should validate_presence_of(:place) }
+    it { should validate_length_of(:place).is_at_most(100) }
+  end
+
+  describe '#content' do
+    it { should validate_presence_of(:content) }
+    it { should validate_length_of(:content).is_at_most(2000) }
+  end
+
+  describe '#start_time' do
+    it { should validate_presence_of(:start_time) }
+  end
+
+  describe '#end_time' do
+    it { should validate_presence_of(:end_time) }
+  end
+
+  describe '#start_time_should_be_before_end_time' do
+    let!(:event) { build(:event) }
+
+    context 'start_time が end_time 以上の時' do
+      before { event.start_time = event.end_time }
+      it { expect(event).to_not be_valid }
+    end
+
+    context 'start_time が end_time 未満の時' do
+      it { expect(event).to be_valid }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'shoulda/matchers'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -59,4 +60,16 @@ RSpec.configure do |config|
   #
   # @see https://www.rubydoc.info/github/thoughtbot/factory_bot/FactoryBot/Syntax/Method
   config.include FactoryBot::Syntax::Methods
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+
+    with.library :active_record
+    with.library :active_model
+    with.library :action_controller
+
+    with.library :rails
+  end
 end


### PR DESCRIPTION
## 概要
### Event モデル、コントローラー、ルーティング、DB 作成
- `$ bundle exec rails g resource event ...` でモデル、コントローラー、ルーティング、マイグレーションファイルを自動作成
- マイグレーションファイルを一部修正して、`$ bundle exec rails db:migrate` で `events` テーブル作成

### Event モデルにバリデーション設定
- バリデーションの内容は以下の通り
    - name, place, start_time, end_time, content は必須入力
    - name は 50 文字以下
    - place は 100 文字以下
    - content は2000 文字以下
    - start_time は end_time よりも前の時間
- gem の `shoulda-matchers` を使用して Model Spec を作成

## 動作確認
### 1. RSpec
- `$ bundle exec rspec spec/models` を実行し、  
`0 failures` が出力されることを確認する

### 2. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する

## その他
### `shoulda-matchers` について調べたこと
-  `should` は `is_expected` とほぼ同義
    - `subject` を記述した場合は、 `subject` のブロック内が expect の対象となる
    - `subject` を記述しない場合は、`RSpec.describe Model` の `Model` が `new` されて評価する
- マッチャの `validates_presence_of` はオブジェクトが Rails のメソッドである [`#validates_presence_of`](http://railsdoc.com/references/validates_presence_of)であるかどうかを評価している
