### PR TITLE
Event#show 実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,7 +21,7 @@
   width: auto;
  }
 
- .display-4 {
+ .display-4, .card {
   padding-bottom: .5rem;
   margin-top: 1.5rem;
   margin-bottom: .5rem;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :authenticate
+  before_action :authenticate, except: :show
 
   def new
     @event = current_user.created_events.build
@@ -12,6 +12,10 @@ class EventsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @event = Event.find(params[:id])
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  belongs_to :owner, class_name: 'User'
+
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,6 +1,8 @@
 <% now = Time.zone.now %>
 
-<h1 class="display-4">イベント作成</h1>
+<div class="display-4">
+  <h1>イベント作成</h1>
+</div>
 
 <%= form_with model: @event, local: true do |f| %>
   <% if @event.errors.any? %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,1 +1,34 @@
-<h1>Event#show</h1>
+<div class="display-4">
+  <h1><%= @event.name %></h1>
+</div>
+
+<div class="card">
+  <div class="card-header">主催者</div>
+  <div class="card-body">
+    <%= link_to("https://twitter.com/#{@event.owner.nickname}") do %>
+      <%= image_tag @event.owner.image_url %>
+      <%= "@#{@event.owner.nickname}" %>
+    <% end %>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-header">開催時間</div>
+  <div class="card-body">
+    <%= @event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= @event.end_time.strftime('%Y/%m/%d %H:%M') %>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-header">開催場所</div>
+  <div class="card-body">
+    <%= @event.place %>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-header">イベント内容</div>
+  <div class="card-body">
+    <%= @event.content %>
+  </div>
+</div>

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :event do
-    owner { build(:user) }
+    owner
     name 'TEST_EVENT_NAME'
     place 'TEST_EVENT_PLACE'
     content 'TEST_EVENT_CONTENT'

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     name 'TEST_EVENT_NAME'
     place 'TEST_EVENT_PLACE'
     content 'TEST_EVENT_CONTENT'
-    start_time Time.zone.now
-    end_time Time.zone.now + 1.hour
+    start_time '2018-07-07 19:00:00'
+    end_time '2018-07-07 21:00:00'
   end
 end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :event do
-    owner_id 1
+    owner { build(:user) }
     name 'TEST_EVENT_NAME'
     place 'TEST_EVENT_PLACE'
     content 'TEST_EVENT_CONTENT'
-    start_time '2018-07-07 19:00:00'
-    end_time '2018-07-07 21:00:00'
+    start_time Time.zone.now
+    end_time Time.zone.now + 1.hour
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user do
+  factory :user, aliases: [:owner] do
     provider 'twitter'
     sequence(:uid, 12345) { |n| "#{n}" }
     nickname 'netwillnet'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,4 +74,9 @@ RSpec.configure do |config|
   #
   # @see https://www.rubydoc.info/github/thoughtbot/factory_bot/FactoryBot/Syntax/Method
   config.include FactoryBot::Syntax::Methods
+
+  # now の スタブで #travel_to の値を使用する
+  #
+  # @see http://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html#method-i-travel_to
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,4 +79,5 @@ RSpec.configure do |config|
   #
   # @see http://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html#method-i-travel_to
   config.include ActiveSupport::Testing::TimeHelpers
+  config.after { travel_back }
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Events', type: :request do
   describe 'POST #create' do
     subject { post events_path, params: params }
 
-    let(:user) { build(:user) }
+    let(:user) { event.owner }
     let!(:event) { build(:event) }
 
     before { get '/auth/twitter/callback' }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -79,4 +79,16 @@ RSpec.describe 'Events', type: :request do
       end
     end
   end
+
+  describe 'GET #show' do
+    subject { get event_path(event.id) }
+
+    let(:user) { event.owner }
+    let(:event) { create(:event) }
+
+    it 'HTTP Status 2xx が返ってくること' do
+      subject
+      expect(response).to be_successful
+    end
+  end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe 'Events', type: :request do
   describe 'POST #create' do
     subject { post events_path, params: params }
 
-    let(:user) { event.owner }
-    let!(:event) { build(:event) }
+    let(:user) { build(:user) }
+    let(:event) { build(:event, owner: user) }
 
     before { get '/auth/twitter/callback' }
 
@@ -83,8 +83,8 @@ RSpec.describe 'Events', type: :request do
   describe 'GET #show' do
     subject { get event_path(event.id) }
 
-    let(:user) { event.owner }
-    let(:event) { create(:event) }
+    let(:user) { build(:user) }
+    let(:event) { create(:event, owner: user) }
 
     it 'HTTP Status 2xx が返ってくること' do
       subject

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe 'EventsSystem', type: :system do
   before do
     OmniAuth.config.mock_auth[:twitter] = log_in_as user
+    travel_to event.start_time
     visit root_path
   end
 
   let(:user) { build(:user) }
-  let!(:event) { build(:event) }
+  let(:event) { build(:event) }
 
   it '"イベントを作る"リンクが表示されていること' do
     expect(page).to have_content 'イベントを作る'

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'EventsSystem', type: :system do
 
   let(:user) { build(:user) }
   let(:event) { build(:event) }
+  let(:event_open_time) { "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}" }
 
   it '"イベントを作る"リンクが表示されていること' do
     expect(page).to have_content 'イベントを作る'
@@ -23,8 +24,7 @@ RSpec.describe 'EventsSystem', type: :system do
       expect(page).to have_content event.name
       expect(page).to have_content event.place
       expect(page).to have_content event.content
-      expect(page).to have_content event.content
-      expect(page).to have_content "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}"
+      expect(page).to have_content event_open_time
     end
   end
 
@@ -62,8 +62,7 @@ RSpec.describe 'EventsSystem', type: :system do
         expect(page).to have_content event.name
         expect(page).to have_content event.place
         expect(page).to have_content event.content
-        expect(page).to have_content event.content
-        expect(page).to have_content "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}"
+        expect(page).to have_content event_open_time
       end
 
       it '"作成しました"メッセージが表示されること' do

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe 'EventsSystem', type: :system do
     expect(page).to have_content 'イベントを作る'
   end
 
+  context 'イベント詳細ページにアクセスした場合' do
+    subject { visit event_path(event.id) }
+    let(:event) { create(:event) }
+
+    it 'イベント詳細ページが表示されること' do
+      subject
+      expect(page).to have_content event.name
+      expect(page).to have_content event.place
+      expect(page).to have_content event.content
+      expect(page).to have_content event.content
+      expect(page).to have_content "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}"
+    end
+  end
+
   context 'ユーザがログインしている場合' do
     before do
       click_link 'Twitterでログイン'
@@ -44,7 +58,11 @@ RSpec.describe 'EventsSystem', type: :system do
 
       it 'イベント詳細ページが表示されること' do
         subject
-        expect(page.current_path).to eq "/events/#{Event.last.id}"
+        expect(page).to have_content event.name
+        expect(page).to have_content event.place
+        expect(page).to have_content event.content
+        expect(page).to have_content event.content
+        expect(page).to have_content "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}"
       end
 
       it '"作成しました"メッセージが表示されること' do

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'EventsSystem', type: :system do
 
   let(:user) { build(:user) }
   let(:event) { build(:event) }
-  let(:event_open_time) { "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}" }
+  let(:event_holding_time) { "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}" }
 
   it '"イベントを作る"リンクが表示されていること' do
     expect(page).to have_content 'イベントを作る'
@@ -24,7 +24,7 @@ RSpec.describe 'EventsSystem', type: :system do
       expect(page).to have_content event.name
       expect(page).to have_content event.place
       expect(page).to have_content event.content
-      expect(page).to have_content event_open_time
+      expect(page).to have_content event_holding_time
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.describe 'EventsSystem', type: :system do
         expect(page).to have_content event.name
         expect(page).to have_content event.place
         expect(page).to have_content event.content
-        expect(page).to have_content event_open_time
+        expect(page).to have_content event_holding_time
       end
 
       it '"作成しました"メッセージが表示されること' do


### PR DESCRIPTION
## 概要
### Event を User に belongs_to関連付け
- `event` ファクトリーで同時に `owner` も作成
- Request Spec の `POST #create` の `user` の中身を `event.owner` に修正

### `Event#show` の実装
- event_controller.rb の before_action から :show を除外
- application.scss の .card に margin と padding の CSS を追加
- イベント詳細ページの作成
- Request Spec, System Spec を作成

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/events/1 にアクセスする
  - イベントを作成していない場合は新規作成をする
- 下図画面の様に、イベントの詳細ページが表示されることを確認する
<img width="600" alt="2018-07-06 15 04 25" src="https://user-images.githubusercontent.com/26681827/42429524-53dbd014-8374-11e8-884c-590eaec7aabc.png">

### 2. RSpec
- `$ bundle exec rspec spec/**/event*_spec.rb` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する

## その他
- `events/new.html.erb` の見出しを `<div>` で囲うよう修正
- 固定の日時にしたらテストが落ちるため、 factories/ `start_time` と `end_time` を現在の時刻と1時間後に修正