### PR TITLE
Event#index 実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :authenticate, except: :show
+  before_action :authenticate, except: [:show, :index]
 
   def new
     @event = current_user.created_events.build
@@ -16,6 +16,10 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+  end
+
+  def index
+    @events = Event.where('start_time > ?', Time.zone.now).order(:start_time)
   end
 
   private

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,5 @@
 class WelcomeController < ApplicationController
   def index
+    redirect_to events_path
   end
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,16 @@
+<div class="display-4 mt-4 mb-2 pb-2">
+  <h1>イベント一覧</h1>
+</div>
+
+<ul class="list-group">
+  <% @events.each do |event| %>
+  <%= link_to(event, class: 'list-group-item') do %>
+    <h4 class="my-auto">
+      <%= event.name %>
+    </h4>
+    <p class="my-auto">
+      <%= event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= event.end_time.strftime('%Y/%m/%d %H:%M') %>
+    </p>
+  <% end %>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'welcome#index'
+  root to: 'events#index'
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout
 

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     place 'TEST_EVENT_PLACE'
     content 'TEST_EVENT_CONTENT'
     start_time '2018-07-07 19:00:00'
-    end_time '2018-07-07 21:00:00'
+    end_time '2018-07-07 22:00:00'
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -96,4 +96,21 @@ RSpec.describe 'Events', type: :request do
       expect(response).to render_template :show
     end
   end
+
+  describe 'GET #index' do
+    subject { get events_path }
+
+    let(:user) { create(:user) }
+    let(:event) { create(:event, owner: user) }
+
+    it 'HTTP Status 2xx が返ってくること' do
+      subject
+      expect(response).to be_successful
+    end
+
+    it ':indexテンプレートを表示すること' do
+      subject
+      expect(response).to render_template :index
+    end
+  end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Events', type: :request do
     subject { get event_path(event.id) }
 
     let(:user) { create(:user) }
-    let(:event) { create(:event, owner: user) }
+    let!(:event) { create(:event, owner: user) }
 
     it 'HTTP Status 2xx が返ってくること' do
       subject
@@ -101,7 +101,7 @@ RSpec.describe 'Events', type: :request do
     subject { get events_path }
 
     let(:user) { create(:user) }
-    let(:event) { create(:event, owner: user) }
+    let!(:event) { create(:event, owner: user) }
 
     it 'HTTP Status 2xx が返ってくること' do
       subject

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -35,6 +35,30 @@ RSpec.describe 'EventsSystem', type: :system do
         expect(page).to have_content event_holding_time
       end
     end
+
+    context 'イベント一覧ページにアクセスした場合' do
+      subject { visit events_path }
+      let(:event) { create(:event) }
+
+      before do
+        create(:event, name: 'future_event_1', start_time: Time.zone.now + 1.hour)
+        create(:event, name: 'future_event_2', start_time: Time.zone.now + 1.hour)
+      end
+
+      it '未開催のイベント一覧が表示されること' do
+        subject
+        expect(page).to have_content 'future_event_1'
+        expect(page).to have_content 'future_event_2'
+        expect(page).to_not have_content event.name
+      end
+
+      it '開始時間順でイベント一覧が表示されること' do
+        subject
+        list_group_item = page.all('.list-group-item')
+        expect(list_group_item[0].find('h4').text).to eq 'future_event_1'
+        expect(list_group_item[1].find('h4').text).to eq 'future_event_2'
+      end
+    end
   end
 
   context 'ユーザがログインしている時' do
@@ -119,17 +143,42 @@ RSpec.describe 'EventsSystem', type: :system do
           end
         end
       end
+    end
 
-      context 'イベント詳細ページにアクセスした時' do
-        before { visit event_path(event.id) }
-        let(:event) { create(:event) }
+    context 'イベント詳細ページにアクセスした時' do
+      subject { visit event_path(event.id) }
+      let(:event) { create(:event) }
 
-        it 'イベント詳細ページが表示されること' do
-          expect(page).to have_content event.name
-          expect(page).to have_content event.place
-          expect(page).to have_content event.content
-          expect(page).to have_content event_holding_time
-        end
+      it 'イベント詳細ページが表示されること' do
+        subject
+        expect(page).to have_content event.name
+        expect(page).to have_content event.place
+        expect(page).to have_content event.content
+        expect(page).to have_content event_holding_time
+      end
+    end
+
+    context 'イベント一覧ページにアクセスした場合' do
+      subject { visit events_path }
+      let(:event) { create(:event) }
+
+      before do
+        create(:event, name: 'future_event_1', start_time: Time.zone.now + 1.hour)
+        create(:event, name: 'future_event_2', start_time: Time.zone.now + 2.hours)
+      end
+
+      it '未開催のイベント一覧が表示されること' do
+        subject
+        expect(page).to have_content 'future_event_1'
+        expect(page).to have_content 'future_event_2'
+        expect(page).to_not have_content event.name
+      end
+
+      it '開始時間順でイベント一覧が表示されること' do
+        subject
+        list_group_item = page.all('.list-group-item')
+        expect(list_group_item[0].find('h4').text).to eq 'future_event_1'
+        expect(list_group_item[1].find('h4').text).to eq 'future_event_2'
       end
     end
   end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'EventsSystem', type: :system do
 
     context 'イベント詳細ページにアクセスした時' do
       before { visit event_path(event.id) }
-      let(:event) { create(:event) }
+      let!(:event) { create(:event) }
 
       it 'イベント詳細ページが表示されること' do
         expect(page).to have_content event.name
@@ -38,7 +38,7 @@ RSpec.describe 'EventsSystem', type: :system do
 
     context 'イベント一覧ページにアクセスした場合' do
       subject { visit events_path }
-      let(:event) { create(:event) }
+      let!(:event) { create(:event) }
 
       before do
         create(:event, name: 'future_event_1', start_time: Time.zone.now + 1.hour)
@@ -147,7 +147,7 @@ RSpec.describe 'EventsSystem', type: :system do
 
     context 'イベント詳細ページにアクセスした時' do
       subject { visit event_path(event.id) }
-      let(:event) { create(:event) }
+      let!(:event) { create(:event) }
 
       it 'イベント詳細ページが表示されること' do
         subject
@@ -160,7 +160,7 @@ RSpec.describe 'EventsSystem', type: :system do
 
     context 'イベント一覧ページにアクセスした場合' do
       subject { visit events_path }
-      let(:event) { create(:event) }
+      let!(:event) { create(:event) }
 
       before do
         create(:event, name: 'future_event_1', start_time: Time.zone.now + 1.hour)


### PR DESCRIPTION
## 概要
### `Event#index` の実装
- `event_controller.rb` の before_action から :index を除外
- イベント一覧ページの作成
  - 開始時間が現在時刻より後のイベントが上から開始時間順に表示される
- Request Spec, System Spec を作成

### ルートパスの変更、リダイレクト
- `Welcome#index` を `events_path` にリダイレクトさせる
- `root_path` を `events#index` に変更

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/events にアクセスする
- 下図画面の様に、イベント一覧ページが表示されることを確認する
  - 一覧が表示されない場合は開始時間が現在時刻以降のイベントを新規作成をして再度確認する

### 2. RSpec
- `$ bundle exec rspec spec/**/event*_spec.rb` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する

## その他
- `spec/system/events_spec.rb` はネストが変だったので修正
- `factoried/event.rb` は時刻の並び順をテストするために、 `end_time` を変更
- `Event#show` , `Event#index` などの既に登録済みの `event` は `let!` で作成するように修正し、 `subject` に影響を与えないようにする