### PR TITLE
Event#destroy の実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -35,6 +35,12 @@ class EventsController < ApplicationController
     end
   end
 
+  def destroy
+    @event = current_user.created_events.find(params[:id])
+    @event.destroy!
+    redirect_to root_path, notice: '削除しました'
+  end
+
   private
 
   def event_params

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -39,6 +39,7 @@
   <div class="col-md-4">
     <% if @event.created_by?(current_user) %>
     <%= link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-lg btn-block' %>
+    <%= link_to 'イベントを削除する', event_path(@event), class: 'btn btn-danger btn-lg btn-block', method: :delete, data: { confirm: '本当に削除しますか？' } %>
     <% end%>
   </div>
 </div>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -176,4 +176,22 @@ RSpec.describe 'Events', type: :request do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    subject { delete event_path(event.id) }
+
+    let(:user) { create(:user) }
+    let!(:event) { create(:event, owner: user) }
+
+    before { get '/auth/twitter/callback' }
+
+    it 'イベントを削除すること' do
+      expect { subject }.to change(Event, :count).by(-1)
+    end
+
+    it 'トップページにリダイレクトすること' do
+      subject
+      expect(response).to redirect_to(root_path)
+    end
+  end
 end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -59,8 +59,37 @@ RSpec.describe 'EventsSystem', type: :system do
         expect(page).to have_content '作成しました'
       end
 
-      it '"イベントを編集する" ボタンが表示されていること' do
+      it '"イベントを編集する"、"イベントを削除する"ボタンが表示されていること' do
         expect(page).to have_content 'イベントを編集する'
+        expect(page).to have_content 'イベントを削除する'
+      end
+
+      context '"イベントを削除する"ボタンをクリックした場合' do
+        before { click_link 'イベントを削除する' }
+
+        it '"本当に削除しますか？"のメッセージが表示される' do
+          expect(page.driver.browser.switch_to.alert.text).to eq '本当に削除しますか？'
+        end
+
+        context 'ダイアログボックスで OK ボタンをクリックした場合' do
+          before { page.driver.browser.switch_to.alert.accept }
+
+          it 'トップページに遷移すること' do
+            expect(page.current_path).to eq '/'
+          end
+
+          it '"削除しました" メッセージが表示されていること' do
+            expect(page).to have_content '削除しました'
+          end
+        end
+
+        context 'ダイアログボックスでキャンセルボタンをクリックした場合' do
+          before { page.driver.browser.switch_to.alert.dismiss }
+
+          it 'ページが遷移しないこと' do
+            expect(page.current_path).to eq "/events/#{Event.order(:created_at).last.id}"
+          end
+        end
       end
     end
   end
@@ -121,8 +150,9 @@ RSpec.describe 'EventsSystem', type: :system do
         expect(page).to have_content "#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}"
       end
 
-      it '"イベントを編集する"リンクが表示されないこと' do
+      it '"イベントを編集する"、"イベントを削除する"ボタンが表示されないこと' do
         expect(page).to_not have_content 'イベントを編集する'
+        expect(page).to_not have_content 'イベントを削除する'
       end
     end
   end


### PR DESCRIPTION
## 概要
### `Event#destroy` の実装
- `app/views/events/show.html.erb` に "イベントを削除する" ボタンの追加
- Request Spec, System Spec の作成

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/events/ にアクセスする
- 画面右上の `Twitterでログイン` をクリックする
- イベント一覧で自分が作成したイベントをクリックする
  - イベントを作成していない場合は新規作成をする
- `イベントを削除する` ボタンをクリックして、ダイアログボックスの OK をクリックする
- 下図画面のようにイベントが削除されていることを確認する

<img width="600" alt="2018-07-18 16 06 08" src="https://user-images.githubusercontent.com/26681827/42865415-8b6aa56e-8aa4-11e8-92f6-29578a766a4d.png">

### 2. RSpec
- `$ bundle exec rspec spec/**/event*_spec.rb` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する