### PR TITLE
Event#show に参加者一覧表示を追加実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -17,6 +17,7 @@ class EventsController < ApplicationController
   def show
     @event = Event.find(params[:id])
     @ticket = Ticket.new
+    @tickets = @event.tickets.includes(:user).order(:created_at)
   end
 
   def index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def url_for_twitter(user)
+    "https://twitter.com/#{user.nickname}"
+  end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,7 +7,7 @@
     <div class="card">
       <div class="card-header">主催者</div>
       <div class="card-body">
-        <%= link_to("https://twitter.com/#{@event.owner.nickname}") do %>
+        <%= link_to(url_for_twitter(@event.owner)) do %>
           <%= image_tag @event.owner.image_url %>
           <%= "@#{@event.owner.nickname}" %>
         <% end %>
@@ -73,5 +73,23 @@
     <% else %>
     <button class="btn btn-light btn-lg btn-block" disabled="disabled">参加するにはログインしてください</button>
     <% end %>
+
+    <hr>
+    <div class="card">
+      <div class="card-header">参加者</div>
+      <div class="card-body">
+        <ul class="list-unstyled">
+        <% @tickets.each do |ticket| %>
+        <li>
+          <%= link_to(url_for_twitter(ticket.user)) do %>
+            <%= image_tag ticket.user.image_url, width: 20, height: 20 %>
+            <%= "@#{ticket.user.nickname}" %>
+          <% end %>
+          <%= ticket.comment %>
+        </li>
+        <% end %>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>

--- a/spec/factories/ticket.rb
+++ b/spec/factories/ticket.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     user
     event
     comment 'TEST_TICKET_COMMENT'
+
+    trait :ticket_2 do
+      comment 'TEST_TICKET_COMMENT_2'
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,5 +4,11 @@ FactoryBot.define do
     sequence(:uid, 12345) { |n| "#{n}" }
     nickname 'netwillnet'
     image_url 'http://example.com/netwillnet.jpg'
+
+    trait :user_2 do
+      sequence(:uid, 23456) { |n| "#{n}" }
+      nickname 'netwillnet_2'
+      image_url 'http://example.com/netwillnet_2.jpg'
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     image_url 'http://example.com/netwillnet.jpg'
 
     trait :user_2 do
-      sequence(:uid, 23456) { |n| "#{n}" }
+      sequence(:uid) { |n| "#{n}" }
       nickname 'netwillnet_2'
       image_url 'http://example.com/netwillnet_2.jpg'
     end

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'TicketsSystem', type: :system do
     end
 
     it '参加順に参加者一覧が表示されること' do
-      list_group_item = page.all(:xpath, '/html/body/div/div[2]/div[2]/div/div[2]/ul/li')
+      list_group_item = page.all(:css, 'div.card-body > ul > li')
 
       expect(list_group_item[0].text).to include user.nickname
       expect(list_group_item[0].text).to include ticket.comment

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -94,4 +94,24 @@ RSpec.describe 'TicketsSystem', type: :system do
       expect(page).to have_content '参加するにはログインしてください'
     end
   end
+
+  context '参加者一覧表示機能' do
+    let!(:user_2) { create(:user, :user_2) }
+    let!(:ticket) { create(:ticket, user: user, event: event) }
+    let!(:ticket_2) { create(:ticket, :ticket_2, user: user_2, event: event) }
+
+    before do
+      click_link 'AwesomeEvents'
+      click_link event.name
+    end
+
+    it '参加順に参加者一覧が表示されること' do
+      list_group_item = page.all(:xpath, '/html/body/div/div[2]/div[2]/div/div[2]/ul/li')
+
+      expect(list_group_item[0].text).to include user.nickname
+      expect(list_group_item[0].text).to include ticket.comment
+      expect(list_group_item[1].text).to include user_2.nickname
+      expect(list_group_item[1].text).to include ticket_2.comment
+    end
+  end
 end


### PR DESCRIPTION
## 概要
### 参加者一覧の実装
- `Event#show` で `@event.tickets` を取得し、`app/views/events/show.html.erb` に表示
- System Spec 作成

### その他
- `application_helper.rb` に `#url_for_twitter` を実装しリプレイス
- User, Ticket の factory 追加

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/events/ にアクセスする
- 画面右上の `Twitterでログイン` をクリックする
- イベント一覧で自分が作成したイベントをクリックする
  - イベントを作成していない場合は新規作成をする
  - イベントに参加していない場合は `参加する` ボタンをクリックして参加する
- 下図のように、イベント詳細ページの参加者一覧に自分のアイコン、アカウント名と参加コメントが表示されることを確認する

<img width="600" alt="2018-07-25 18 37 12" src="https://user-images.githubusercontent.com/26681827/43192977-cfb57470-9039-11e8-841d-f357f9d0368f.png">


### 2. RSpec
- `$ bundle exec rspec` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する

## その他
- Response が変わるような処理は記述していないと思うので、 Request Spec は記述していません。