### PR TITLE
Ticket#destroy 実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  helper_method :current_user, :logged_in?, :ticket?
+  helper_method :current_user, :logged_in?
 
   private
 
@@ -15,9 +15,5 @@ class ApplicationController < ActionController::Base
   def authenticate
     return if logged_in?
     redirect_to root_path, alert: 'ログインしてください'
-  end
-
-  def ticket?(event)
-    current_user.events.include?(event)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,6 +18,7 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     @ticket = Ticket.new
     @tickets = @event.tickets.includes(:user).order(:created_at)
+    @current_user_ticket = current_user&.tickets&.find_by(event_id: params[:id])
   end
 
   def index

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -14,4 +14,10 @@ class TicketsController < ApplicationController
       render json: { messages: ticket.errors.full_messages }, status: 422
     end
   end
+
+  def destroy
+    ticket = current_user.tickets.find_by!(event_id: params[:event_id])
+    ticket.destroy!
+    redirect_to event_path(params[:event_id]), notice: 'このイベントの参加をキャンセルしました'
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 class Event < ApplicationRecord
   belongs_to :owner, class_name: 'User'
-  has_many :tickets
+  has_many :tickets, dependent: :destroy
   has_many :users, through: :tickets
 
   validates :name, length: { maximum: 50 }, presence: true

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -43,8 +43,8 @@
     <% end%>
 
     <% if logged_in? %>
-      <% if ticket?(@event) %>
-      <button class="btn btn-secondary btn-lg btn-block" disabled="disabled">参加登録済み</button>
+      <% if @current_user_ticket %>
+      <%= link_to '参加をキャンセルする', event_ticket_path(@event, @current_user_ticket), method: :delete, class: 'btn btn-warning btn-lg btn-block' %>
       <% else %>
       <button class="btn btn-primary btn-lg btn-block" data-toggle="modal" data-target="#createTicket">参加する</button>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   get '/logout' => 'sessions#destroy', as: :logout
 
   resources :events do
-    resources :tickets, only: :create
+    resources :tickets, only: [:create, :destroy]
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Event, type: :model do
   describe 'association' do
     it { is_expected.to belong_to(:owner) }
-    it { is_expected.to have_many(:tickets) }
+    it { is_expected.to have_many(:tickets).dependent(:destroy) }
     it { is_expected.to have_many(:users) }
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -182,11 +182,16 @@ RSpec.describe 'Events', type: :request do
 
     let(:user) { create(:user) }
     let!(:event) { create(:event, owner: user) }
+    let!(:ticket) { create(:ticket, user: user, event: event) }
 
     before { get '/auth/twitter/callback' }
 
     it 'イベントを削除すること' do
       expect { subject }.to change(Event, :count).by(-1)
+    end
+
+    it '関連するチケットを削除すること' do
+      expect { subject }.to change(Ticket, :count).by(-1)
     end
 
     it 'トップページにリダイレクトすること' do

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -46,4 +46,21 @@ RSpec.describe 'Tickets', type: :request do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    subject { delete event_ticket_path(event, ticket) }
+
+    let!(:ticket) { create(:ticket, user: user, event: event) }
+
+    before { get '/auth/twitter/callback' }
+
+    it 'チケットを削除すること' do
+      expect { subject }.to change(Ticket, :count).by(-1)
+    end
+
+    it 'イベント詳細ページにリダイレクトすること' do
+      subject
+      expect(response).to redirect_to(event_path(event.id))
+    end
+  end
 end

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -78,8 +78,27 @@ RSpec.describe 'TicketsSystem', type: :system do
       click_link event.name
     end
 
-    it '"参加登録済み"ボタンが表示されること' do
-      expect(page).to have_content '参加登録済み'
+    it '"参加をキャンセルする"リンクが表示されること' do
+      expect(page).to have_content '参加をキャンセルする'
+    end
+
+    describe '"参加をキャンセルする"リンクをクリックした場合' do
+      before { click_link '参加をキャンセルする' }
+
+      it '"このイベントの参加をキャンセルしました"メッセージが表示されること' do
+        expect(page).to have_content 'このイベントの参加をキャンセルしました'
+      end
+
+      it '"参加する"リンクが表示されること' do
+        expect(page).to have_content '参加する'
+      end
+
+      it '参加者一覧にログインユーザが表示されないこと' do
+        list_group = page.find(:css, 'div.card-body > ul')
+
+        expect(list_group.text).to_not have_content user.nickname
+        expect(list_group.text).to_not have_content ticket.comment
+      end
     end
   end
 


### PR DESCRIPTION
## 概要
### `Ticket#destroy` の実装
- ルーティングの作成
- ログインユーザの該当イベントの `ticket` を格納し、削除を行う
- Request Spec の作成

### View の実装
- `app/views/events/show.html.erb` から `参加登録済み` ボタンを削除して、 `参加をキャンセルする` リンクを実装
- System Spec を作成

### その他
- `Event#show` で `@current_user_ticket` を格納したため、 `#ticket?` を削除、リプレイス
- `Event` が削除されると関連した `Ticket` も削除される設定を追加

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/events/ にアクセスする
- 画面右上の `Twitterでログイン` をクリックする
- イベント一覧で自分が作成したイベントをクリックする
  - イベントを作成していない場合は新規作成をする
  - イベントに参加していない場合は `参加する` ボタンをクリックして参加する
- `参加をキャンセルする` リンクをクリックした時、下図のように `このイベントの参加をキャンセルしました` のメッセージが表示され、参加者一覧からログインユーザの名前が消えていること

<img width="600" alt="2018-07-27 15 20 43" src="https://user-images.githubusercontent.com/26681827/43304872-a9b9429c-91b0-11e8-93b8-a946614a3fd2.png">


### 2. RSpec
- `$ bundle exec rspec` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する