### PR TITLE
User#destroy の実装

### DIFF
--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate
+
+  def retire
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,4 +3,13 @@ class UsersController < ApplicationController
 
   def retire
   end
+
+  def destroy
+    if current_user.destroy
+      reset_session
+      redirect_to root_path, notice: '退会完了しました'
+    else
+      render :retire
+    end
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,6 @@ class User < ApplicationRecord
     now = Time.zone.now
     errors[:base] << '公開中の未終了イベントが存在します。' if created_events.where(':now < end_time', now: now).exists?
     errors[:base] << '未終了の参加イベントが存在します。' if participating_events.where(':now < end_time', now: now).exists?
-    errors.blank?
+    throw(:abort) if errors.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   before_destroy :check_all_events_finished
 
   has_many :created_events, class_name: 'Event', foreign_key: :owner_id, dependent: :nullify
-  has_many :tickets
-  has_many :events, through: :tickets
+  has_many :tickets, dependent: :nullify
+  has_many :events, through: :tickets, dependent: :nullify
   has_many :participating_events, through: :tickets, source: :event, dependent: :nullify
 
   def self.find_or_create_from_auth_hash(auth_hash)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
-  has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+  has_many :created_events, class_name: 'Event', foreign_key: :owner_id, dependent: :nullify
   has_many :tickets
   has_many :events, through: :tickets
+  has_many :participating_events, through: :tickets, source: :event, dependent: :nullify
 
   def self.find_or_create_from_auth_hash(auth_hash)
     provider = auth_hash[:provider]

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,9 +7,13 @@
     <div class="card">
       <div class="card-header">主催者</div>
       <div class="card-body">
+        <% if @event.owner %>
         <%= link_to(url_for_twitter(@event.owner)) do %>
           <%= image_tag @event.owner.image_url %>
           <%= "@#{@event.owner.nickname}" %>
+        <% end %>
+        <% else %>
+        退会したユーザです
         <% end %>
       </div>
     </div>
@@ -81,11 +85,15 @@
         <ul class="list-unstyled">
         <% @tickets.each do |ticket| %>
         <li>
+          <% if ticket.user %>
           <%= link_to(url_for_twitter(ticket.user)) do %>
             <%= image_tag ticket.user.image_url, width: 20, height: 20 %>
             <%= "@#{ticket.user.nickname}" %>
           <% end %>
           <%= ticket.comment %>
+          <% else %>
+          退会したユーザです
+          <% end %>
         </li>
         <% end %>
         </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,13 +27,18 @@
             <li class="nav-item">
               <%= link_to 'イベントを作る', new_event_path, class: 'nav-link' %>
             </li>
+            <% if logged_in? %>
             <li class="nav-item">
-              <% if logged_in? %>
-              <%= link_to 'ログアウト', logout_path, class: 'nav-link' %>
-              <% else %>
-              <%= link_to 'Twitterでログイン', '/auth/twitter', class: 'nav-link' %>
-              <% end %>
+              <%= link_to '退会', user_retire_path, class: 'nav-link' %>
             </li>
+            <li class="nav-item">
+              <%= link_to 'ログアウト', logout_path, class: 'nav-link' %>
+            </li>
+            <% else %>
+            <li class="nav-item">
+              <%= link_to 'Twitterでログイン', '/auth/twitter', class: 'nav-link' %>
+            </li>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/app/views/users/retire.html.erb
+++ b/app/views/users/retire.html.erb
@@ -21,4 +21,4 @@
 
 <hr>
 
-<%= link_to '退会する', '#', method: :delete, class: 'btn btn-danger' %>
+<%= link_to '退会する', user_path(current_user), method: :delete, class: 'btn btn-danger' %>

--- a/app/views/users/retire.html.erb
+++ b/app/views/users/retire.html.erb
@@ -1,0 +1,24 @@
+<div class="display-4 mt-4 mb-2 pb-2">
+  <h1>退会の確認</h1>
+</div>
+
+<% if current_user.errors.any? %>
+<div class="alert alert-danger mt-4 mb-2 pb-2">
+  <ul>
+    <% current_user.errors.full_messages.each do |msg| %>
+    <li><%= msg %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>
+
+<p>退会した場合、ユーザに関するデータが全て削除されます。</p>
+<p>ただし、以下の場合は退会できません。</p>
+<ul>
+  <li>公開中の未終了のイベントがある場合</li>
+  <li>未終了の参加イベントがある場合</li>
+</ul>
+
+<hr>
+
+<%= link_to '退会する', '#', method: :delete, class: 'btn btn-danger' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/logout' => 'sessions#destroy', as: :logout
   get '/users/retire' => 'users#retire', as: :user_retire
 
+  resources :users, only: :destroy
   resources :events do
     resources :tickets, only: [:create, :destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'events#index'
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout
+  get '/users/retire' => 'users#retire', as: :user_retire
 
   resources :events do
     resources :tickets, only: [:create, :destroy]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,4 +7,33 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:participating_events) }
   end
+
+  describe '#check_all_events_finished' do
+    subject { user.send(:check_all_events_finished) }
+
+    let!(:user) { build(:user) }
+    let!(:other_user) { create(:user, :user_2) }
+
+    before do
+      OmniAuth.config.mock_auth[:twitter] = log_in_as user
+      allow(Time.zone).to receive(:now).and_return('2018-07-07 11:30:00'.to_datetime)
+    end
+
+    context '公開中の未終了イベントも未終了の参加イベントもない場合' do
+      it { expect(subject).to eq true }
+    end
+
+    context '公開中の未終了イベントがある場合' do
+      let!(:future_event) { create(:event, :future_event, owner: user) }
+
+      it { expect(subject).to eq false }
+    end
+
+    context '未終了の参加イベントがある場合' do
+      let!(:future_event) { create(:event, :future_event, owner: other_user) }
+      let!(:ticket) { create(:ticket, user: user, event: future_event) }
+
+      it { expect(subject).to eq false }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,5 +5,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:created_events) }
     it { is_expected.to have_many(:tickets) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_many(:participating_events) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,33 +7,4 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:participating_events) }
   end
-
-  describe '#check_all_events_finished' do
-    subject { user.send(:check_all_events_finished) }
-
-    let!(:user) { build(:user) }
-    let!(:other_user) { create(:user, :user_2) }
-
-    before do
-      OmniAuth.config.mock_auth[:twitter] = log_in_as user
-      allow(Time.zone).to receive(:now).and_return('2018-07-07 11:30:00'.to_datetime)
-    end
-
-    context '公開中の未終了イベントも未終了の参加イベントもない場合' do
-      it { expect(subject).to eq true }
-    end
-
-    context '公開中の未終了イベントがある場合' do
-      let!(:future_event) { create(:event, :future_event, owner: user) }
-
-      it { expect(subject).to eq false }
-    end
-
-    context '未終了の参加イベントがある場合' do
-      let!(:future_event) { create(:event, :future_event, owner: other_user) }
-      let!(:ticket) { create(:ticket, user: user, event: future_event) }
-
-      it { expect(subject).to eq false }
-    end
-  end
 end

--- a/spec/requests/retire_spec.rb
+++ b/spec/requests/retire_spec.rb
@@ -2,32 +2,54 @@ require 'rails_helper'
 
 RSpec.describe 'RetireRequest', type: :request do
   let(:user) { create(:user) }
-  let(:event) { create(:event, owner: user) }
+  let!(:other_user) { create(:user, :user_2) }
 
-  before { OmniAuth.config.mock_auth[:twitter] = log_in_as user }
+  before do
+    OmniAuth.config.mock_auth[:twitter] = log_in_as user
+    allow(Time.zone).to receive(:now).and_return('2018-07-07 11:30:00'.to_datetime)
+  end
 
   describe 'DELETE #destroy' do
     subject { delete "/users/#{user.id}" }
 
     before { get '/auth/twitter/callback' }
 
-    it 'HTTP Status 3xx が返ってくること' do
-      subject
-      expect(response).to be_redirect
+    context '公開中の未終了イベントも未終了の参加イベントもない場合' do
+      it 'HTTP Status 3xx が返ってくること' do
+        subject
+        expect(response).to be_redirect
+      end
+
+      it 'ユーザを削除すること' do
+        expect { subject }.to change(User, :count).by(-1)
+      end
+
+      it 'セッションを削除すること' do
+        subject
+        expect(session[:user_id]).to be_nil
+      end
+
+      it 'トップページにリダイレクトすること' do
+        subject
+        expect(response).to redirect_to(root_path)
+      end
     end
 
-    it 'ユーザを削除すること' do
-      expect { subject }.to change(User, :count).by(-1)
+    context '公開中の未終了イベントがある場合' do
+      let!(:future_event) { create(:event, :future_event, owner: user) }
+
+      it 'ユーザを削除しないこと' do
+        expect { subject }.to_not change(User, :count)
+      end
     end
 
-    it 'セッションを削除すること' do
-      subject
-      expect(session[:user_id]).to be_nil
-    end
+    context '未終了の参加イベントがある場合' do
+      let!(:future_event) { create(:event, :future_event, owner: other_user) }
+      let!(:ticket) { create(:ticket, user: user, event: future_event) }
 
-    it 'トップページにリダイレクトすること' do
-      subject
-      expect(response).to redirect_to(root_path)
+      it 'ユーザを削除しないこと' do
+        expect { subject }.to_not change(User, :count)
+      end
     end
   end
 end

--- a/spec/requests/retire_spec.rb
+++ b/spec/requests/retire_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'RetireRequest', type: :request do
+  let(:user) { create(:user) }
+  let(:event) { create(:event, owner: user) }
+
+  before { OmniAuth.config.mock_auth[:twitter] = log_in_as user }
+
+  describe 'DELETE #destroy' do
+    subject { delete "/users/#{user.id}" }
+
+    before { get '/auth/twitter/callback' }
+
+    it 'HTTP Status 3xx が返ってくること' do
+      subject
+      expect(response).to be_redirect
+    end
+
+    it 'ユーザを削除すること' do
+      expect { subject }.to change(User, :count).by(-1)
+    end
+
+    it 'セッションを削除すること' do
+      subject
+      expect(session[:user_id]).to be_nil
+    end
+
+    it 'トップページにリダイレクトすること' do
+      subject
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/system/retire_spec.rb
+++ b/spec/system/retire_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'RetireSystem', type: :system do
     expect(page).to have_content '退会'
   end
 
-  context '”退会"ボタンを押した時' do
+  describe '”退会"ボタンを押した時' do
     before { click_link '退会' }
 
     it '正しくページが表示されること' do
@@ -24,6 +24,21 @@ RSpec.describe 'RetireSystem', type: :system do
         expect(page).to have_content '退会の確認'
         expect(page).to have_link '退会する'
       end
+    end
+  end
+
+  describe '”退会する"ボタンを押した時' do
+    before do
+      click_link '退会'
+      click_link '退会する'
+    end
+
+    it 'トップページに遷移すること' do
+      expect(page.current_path).to eq '/'
+    end
+
+    it '"退会完了しました" メッセージが表示されていること' do
+      expect(page).to have_content '退会完了しました'
     end
   end
 end

--- a/spec/system/retire_spec.rb
+++ b/spec/system/retire_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'RetireSystem', type: :system do
+  let!(:user) { create(:user) }
+  let!(:event) { create(:event, owner: user) }
+
+  before do
+    travel_to '2018-07-07 18:30:00'
+    OmniAuth.config.mock_auth[:twitter] = log_in_as user
+    visit '/'
+    click_link 'Twitterでログイン'
+    click_link 'AwesomeEvents'
+  end
+
+  it '"退会"ボタンが表示されること' do
+    expect(page).to have_content '退会'
+  end
+end

--- a/spec/system/retire_spec.rb
+++ b/spec/system/retire_spec.rb
@@ -63,4 +63,42 @@ RSpec.describe 'RetireSystem', type: :system do
       end
     end
   end
+
+  describe 'ユーザが退会した時' do
+    subject do
+      travel_to '2018-07-07 17:00:00'
+      click_link 'AwesomeEvents'
+      click_link past_event.name
+    end
+
+    before do
+      travel_to '2018-07-07 23:00:00'
+      click_link '退会'
+    end
+
+    context '主催者が退会した場合' do
+      let!(:past_event) { create(:event, :past_event, owner: user) }
+
+      before { click_link '退会する' }
+
+      it '主催者に"退会したユーザです"が表示されること' do
+        subject
+        organizer = page.find(:css, 'div:nth-child(1) > div.card-body')
+        expect(organizer.text).to eq '退会したユーザです'
+      end
+    end
+
+    context '参加者が退会した場合' do
+      let!(:past_event) { create(:event, :past_event, owner: other_user) }
+      let!(:ticket) { create(:ticket, user: user, event: past_event) }
+
+      before { click_link '退会する' }
+
+      it '参加者に"退会したユーザです"が表示されること' do
+        subject
+        list_group = page.find(:css, 'div.card-body > ul')
+        expect(list_group.text).to have_content '退会したユーザです'
+      end
+    end
+  end
 end

--- a/spec/system/retire_spec.rb
+++ b/spec/system/retire_spec.rb
@@ -69,19 +69,15 @@ RSpec.describe 'RetireSystem', type: :system do
     end
   end
 
-  describe 'ユーザが退会した時' do
-    subject do
-      travel_to '2018-07-07 17:00:00'
-      click_link 'AwesomeEvents'
-      click_link past_event.name
-    end
+  describe 'ユーザが退会後、イベント詳細ページを閲覧した時' do
+    subject { visit "/events/#{past_event.id}" }
 
     before do
       travel_to '2018-07-07 23:00:00'
       click_link '退会'
     end
 
-    context '主催者が退会した場合' do
+    context 'イベント主催者が退会した場合' do
       let!(:past_event) { create(:event, :past_event, owner: user) }
 
       before { click_link '退会する' }
@@ -93,7 +89,7 @@ RSpec.describe 'RetireSystem', type: :system do
       end
     end
 
-    context '参加者が退会した場合' do
+    context 'イベント参加者が退会した場合' do
       let!(:past_event) { create(:event, :past_event, owner: other_user) }
       let!(:ticket) { create(:ticket, user: user, event: past_event) }
 

--- a/spec/system/retire_spec.rb
+++ b/spec/system/retire_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'RetireSystem', type: :system do
   let!(:other_user) { create(:user, :user_2) }
 
   before do
-    travel_to '2018-07-07 18:30:00'
     OmniAuth.config.mock_auth[:twitter] = log_in_as user
     visit '/'
     click_link 'Twitterでログイン'
@@ -17,7 +16,10 @@ RSpec.describe 'RetireSystem', type: :system do
   end
 
   describe '”退会"ボタンを押した時' do
-    before { click_link '退会' }
+    before do
+      travel_to '2018-07-07 18:30:00'
+      click_link '退会'
+    end
 
     it '正しくページが表示されること' do
       aggregate_failures do
@@ -30,7 +32,10 @@ RSpec.describe 'RetireSystem', type: :system do
   describe '”退会する"ボタンを押した時' do
     subject { click_link '退会する' }
 
-    before { click_link '退会' }
+    before do
+      travel_to '2018-07-07 18:30:00'
+      click_link '退会'
+    end
 
     context '公開中の未終了イベントも未終了の参加イベントもない場合' do
       it 'トップページに遷移すること' do

--- a/spec/system/retire_spec.rb
+++ b/spec/system/retire_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe 'RetireSystem', type: :system do
   it '"退会"ボタンが表示されること' do
     expect(page).to have_content '退会'
   end
+
+  context '”退会"ボタンを押した時' do
+    before { click_link '退会' }
+
+    it '正しくページが表示されること' do
+      aggregate_failures do
+        expect(page).to have_content '退会の確認'
+        expect(page).to have_link '退会する'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- 退会確認ページを作成する
- ユーザを削除する `user#destroy` を実装する
  - 公開中の未終了のイベントも未終了の参加イベントもない場合のみ削除できるようにする
- 退会したユーザについては、イベント詳細ページで `退会したユーザです` と表示する

## 動作確認
### 1. Rails
- `$ bin/setup` を実行する
- `$ bundle exec rails server` を実行する
- ブラウザ上で http://lvh.me:3000/events/ にアクセスする
- 画面右上の `Twitterでログイン` をクリックする

#### 公開中の未終了のイベントも未終了の参加イベントもない場合
- 画面右上の `退会` をクリックする
- `退会する` ボタンをクリックする
- [ ] 下図のように `退会完了しました` メッセージが表示されていることを確認する
<img width="600" alt="2018-08-30 16 05 45" src="https://user-images.githubusercontent.com/26681827/44835243-991d1480-ac6e-11e8-82f2-843b5d944ed0.png">

#### 公開中の未終了のイベントも未終了の参加イベントがある場合
- 開始時刻が現在時刻以降のイベントを新規作成をする
- 作成したイベントに参加する
- 画面右上の `退会` をクリックする
- `退会する` ボタンをクリックする
- [ ] 下図のように  `公開中の未終了イベントが存在します。` `未終了の参加イベントが存在します。` メッセージが表示されていることを確認する
<img width="600" alt="2018-08-30 16 15 42" src="https://user-images.githubusercontent.com/26681827/44835719-fcf40d00-ac6f-11e8-9eea-91c2b613153e.png">

### 2. RSpec
- `$ bundle exec rspec` を実行し、  
`0 failures` が出力されることを確認する

### 3. Rubocop
- `$ bundle exec rubocop` を実行し、  
`no offenses detected` が出力されることを確認する